### PR TITLE
make pdf-tools display retina image on emacs NS-port

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -982,7 +982,8 @@ other annotations."
                 page (car size)
                 `("white" "steel blue" 0.35 ,@edges))
              :map (pdf-view-apply-hotspot-functions
-                   window page size))))
+                   window page size)
+             :width (car size))))
         (pdf-util-scroll-to-edges
          (pdf-util-scale-relative-to-pixel (car edges)))))))
 

--- a/lisp/pdf-isearch.el
+++ b/lisp/pdf-isearch.el
@@ -742,7 +742,7 @@ MATCH-BG LAZY-FG LAZY-BG\)."
                                  occur-hack-p)
                              (eq page (pdf-view-current-page)))
                     (pdf-view-display-image
-                     (pdf-view-create-image data))))))))
+                     (pdf-view-create-image data :width width))))))))
       (pdf-info-renderpage-text-regions
        page width t nil
        `(,fg1 ,bg1 ,@(pdf-util-scale-pixel-to-relative

--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -947,7 +947,9 @@ frame's PPI is larger than 180. Otherwise, return 1."
           (if (>= (pdf-util-frame-ppi) 180)
               2
             1))
-    1))
+    (if (and (pdf-view-use-scaling-p) (eq (framep-on-display) 'ns))
+        2
+      1)))
 
 
 ;; * ================================================================== *

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -922,8 +922,9 @@ See also `pdf-view-use-imagemagick'."
 
 (defun pdf-view-use-scaling-p ()
   "Return t if scaling should be used."
-  (and (memq (pdf-view-image-type)
-             '(imagemagick image-io))
+  (and (or (and (eq (framep-on-display) 'ns) (string-equal emacs-version "27.0.50"))
+           (memq (pdf-view-image-type)
+                 '(imagemagick image-io)))
        pdf-view-use-scaling))
 
 (defmacro pdf-view-create-image (data &rest props)
@@ -1409,7 +1410,8 @@ This is more useful for commands like
               `(,(car colors) ,(cdr colors) 0.35 ,@region))
            (pdf-info-renderpage-text-regions
             page width nil nil
-            `(,(car colors) ,(cdr colors) ,@region)))))))
+            `(,(car colors) ,(cdr colors) ,@region)))
+       :width width))))
 
 (defun pdf-view-kill-ring-save ()
   "Copy the region to the `kill-ring'."


### PR DESCRIPTION
----

This PR make use of the native image transform on Emacs NS-port master branch
and let pdf-tools display high resolution image on Emacs.